### PR TITLE
Add invoke activity handler to support file upload

### DIFF
--- a/core/activity/handler.go
+++ b/core/activity/handler.go
@@ -59,15 +59,11 @@ func (r HandlerFuncs) OnInvoke(turn *TurnContext) (schema.Activity, error) {
 // PrepareActivityContext routes the received Activity to respective handler function.
 // Returns the result of the handler function.
 func PrepareActivityContext(handler Handler, context *TurnContext) (schema.Activity, error) {
-	var activity schema.Activity
-	var err error
 	switch context.Activity.Type {
 	case schema.Message:
-		activity, err = handler.OnMessage(context)
+		return handler.OnMessage(context)
 	case schema.Invoke:
-		activity, err = handler.OnInvoke(context)
-	default:
-		return schema.Activity{}, fmt.Errorf("Activity type %s not supported yet", context.Activity.Type)
+		return handler.OnInvoke(context)
 	}
-	return activity, err
+	return schema.Activity{}, fmt.Errorf("Activity type %s not supported yet", context.Activity.Type)
 }

--- a/samples/file-upload/README.md
+++ b/samples/file-upload/README.md
@@ -1,0 +1,144 @@
+# Bot Framework File Upload Sample
+
+This Microsoft Teams bot example uses the [msbotbuilder-go](https://github.com/infracloudio/msbotbuilder-go) library. It shows how to handle `invoke` activity and upload local file from Bot to use.
+
+As documented [here](https://developer.microsoft.com/en-us/microsoft-teams/blogs/working-with-files-in-your-microsoft-teams-bot/), following is the workflow for sending files from Bot to user:
+
+1. **Request permission to upload the file:**
+    First, ask the user for permission to upload a file by sending a file `consent card`.
+2. **User accepts or declines the file**
+    When the user presses either “Allow” or “Decline”, your bot will receive an invoke activity.
+3. **Handle invoke activity**
+    If the file was accepted, activity value contains an uploadInfo property. To set the file contents, issue PUT requests to the URL in uploadInfo.uploadUrl as described [here](https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_createuploadsession?view=odsp-graph-online#upload-bytes-to-the-upload-session)
+4. **Send the user a link to the uploaded file**
+    After you finish the upload, send a link to the file with file `info card`.
+
+## Run the example
+
+#### Step 1: Register MS BOT
+
+Follow the official [documentation](https://docs.microsoft.com/en-us/microsoftteams/platform/bots/how-to/create-a-bot-for-teams#register-your-web-service-with-the-bot-framework) to create and register your BOT.
+
+Copy `APP_ID` and `APP_PASSWORD` generated for your BOT.
+
+Do not set any messaging endpoint for now.
+
+#### Step 2: Run echo local server
+
+Set two variables for the session as `APP_ID` and `APP_PASSWORD` to the values of your BotFramework `APP_ID` and `APP_PASSWORD`. Then run the `main.go` file.
+
+```bash
+export APP_PASSWORD=MICROSOFT_APP_PASSWORD
+export APP_ID=MICROSOFT_APP_ID
+
+go run main.go
+```
+
+This will start a server which will listen on port `3978`
+
+#### Step 3: Expose local server with ngrok
+
+Now, in separate terminal, run [ngrok](https://ngrok.com/download) command to expose your local server to outside world.
+
+```sh
+$ ngrok http 3978
+```
+
+Copy `https` endpoint, go to [Bot Framework](https://dev.botframework.com/bots) dashboard and set messaging endpoint under Settings.
+
+#### Step 4: Test the BOT
+
+You can either test BOT on BotFramework portal or you can create app manifest and install the App on Teams as mentioned [here](https://docs.microsoft.com/en-us/microsoftteams/platform/bots/how-to/create-a-bot-for-teams#create-your-app-manifest-and-package).
+
+
+## Understanding the example
+
+The program starts by creating a handler structs of type `activity.HandlerFuncs`.
+
+This example contains following handlers:
+
+`OnMessageFunc` - sends upload request to user using file `consent card`
+
+`OnInvokeFunc` - parses `invoke` activity, uploads file and notifies user with file `info card`
+
+
+The `init` function picks up the `APP_ID` and `APP_PASSWORD` from the environment session and creates an `adapter` using this.
+
+
+A webserver is started with a handler which passes the received payload to `adapter.ParseRequest`. This methods authenticates the payload, parses the request and returns an Activity value.
+
+```
+activity, err := adapter.ParseRequest(ctx, req)
+```
+  
+
+The Activity is then passed to `adapter.ProcessActivity` with the handler created to process the activity as per the handler functions and send the response to the connector service.
+
+```
+err = adapter.ProcessActivity(ctx, activity, customHandler)
+```
+
+Once the incoming activity is processed, file `consent card` is sent to ask user for file upload permission
+
+e.g
+
+```
+{
+    "contentType": "application/vnd.microsoft.teams.card.file.consent",
+    "name": "data.txt",
+    "content": {
+        "description": "Sample data",
+        "sizeInBytes": 29,
+        "acceptContext": {
+            "resultId": <unique-id>
+        },
+        "declineContext": {
+            "resultId": <unique-id>
+        }
+    }
+```
+
+Based on user's response, `invoke` activity is sent to Bot, which we handle in `OnInvokeFunc`
+
+In `OnInvokeFunc`, we find `uploadInfo` from the `invoke` activity which has following fields:
+
+```
+    "type": "invoke",
+    "name": "fileConsent/invoke",
+    ...
+    "value": {
+        "type": "fileUpload",
+        "action": "accept",
+        "context": {
+            "resultId": <unique-id>
+        },
+        "uploadInfo": {
+            "contentUrl": "https://<onedrive_url>/data.txt",
+            "name": "data.txt",
+            "uploadUrl": "https://<onedrive_upload_url>",
+            "uniqueId": <unique-id>,
+            "fileType": "txt"
+        }
+```
+
+Then, the file contents are uploaded on `uploadUrl` using `PUT` request
+
+```
+err = putRequest(uploadInfo.UploadURL, data)
+```
+
+Finally, user is notified with the file info using `file info card`
+
+```
+{
+    "contentType": "application/vnd.microsoft.teams.card.file.info",
+    "contentUrl": "<uploadInfo.contentUrl>",
+    "name": "<uploadInfo.name>",
+    "content": {
+        "uniqueId": "<uploadInfo.uniqueId>",
+        "fileType": "<uploadInfo.fileType>",
+    }
+}
+```
+
+In case of no error, this web server responds with a 200 status.

--- a/samples/file-upload/data.txt
+++ b/samples/file-upload/data.txt
@@ -1,0 +1,1 @@
+This is a sample attachment.

--- a/samples/file-upload/main.go
+++ b/samples/file-upload/main.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/infracloudio/msbotbuilder-go/core"
+	"github.com/infracloudio/msbotbuilder-go/core/activity"
+	"github.com/infracloudio/msbotbuilder-go/schema"
+)
+
+var customHandler = activity.HandlerFuncs{
+	// handle message events
+	OnMessageFunc: func(turn *activity.TurnContext) (schema.Activity, error) {
+		fi, err := os.Stat("data.txt")
+		if err != nil {
+			return schema.Activity{}, fmt.Errorf("failed to read file: %s", err.Error())
+		}
+
+		// send file upload request
+		attachments := []schema.Attachment{
+			{
+				ContentType: "application/vnd.microsoft.teams.card.file.consent",
+				Name:        "data.txt",
+				Content: map[string]interface{}{
+					"description": "Sample data",
+					"sizeInBytes": fi.Size(),
+				},
+			},
+		}
+		return turn.SendActivity(activity.MsgOptionText("Echo: "+turn.Activity.Text), activity.MsgOptionAttachments(attachments))
+	},
+	// handle invoke events
+	// https://developer.microsoft.com/en-us/microsoft-teams/blogs/working-with-files-in-your-microsoft-teams-bot/
+	OnInvokeFunc: func(turn *activity.TurnContext) (schema.Activity, error) {
+		data, err := ioutil.ReadFile("data.txt")
+		if err != nil {
+			return schema.Activity{}, fmt.Errorf("failed to read file: %s", err.Error())
+		}
+		if turn.Activity.Value["type"] != "fileUpload" {
+			return schema.Activity{}, nil
+		}
+		if turn.Activity.Value["action"] != "accept" {
+			return schema.Activity{}, nil
+		}
+
+		// parse upload info from invoke accept response
+		uploadInfo := schema.UploadInfo{}
+		infoJSON, err := json.Marshal(turn.Activity.Value["uploadInfo"])
+		if err != nil {
+			return schema.Activity{}, err
+		}
+		err = json.Unmarshal(infoJSON, &uploadInfo)
+		if err != nil {
+			return schema.Activity{}, err
+		}
+
+		// upload file
+		err = putRequest(uploadInfo.UploadURL, data)
+		if err != nil {
+			return schema.Activity{}, fmt.Errorf("failed to upload file: %s", err.Error())
+		}
+
+		// notify user about uploaded file
+		fileAttach := []schema.Attachment{
+			{
+				ContentType: "application/vnd.microsoft.teams.card.file.info",
+				ContentURL:  uploadInfo.ContentURL,
+				Name:        uploadInfo.Name,
+				Content: map[string]interface{}{
+					"uniqueId": uploadInfo.UniqueID,
+					"fileType": uploadInfo.FileType,
+				},
+			},
+		}
+
+		return turn.SendActivity(activity.MsgOptionAttachments(fileAttach))
+	},
+}
+
+func putRequest(u string, data []byte) error {
+	client := &http.Client{}
+	dec, err := url.QueryUnescape(u)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPut, dec, bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+	size := fmt.Sprintf("%d", len(data))
+	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("Content-Length", size)
+	req.Header.Set("Content-Range", fmt.Sprintf("bytes 0-%d/%d", len(data)-1, len(data)))
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 201 && resp.StatusCode != 200 {
+		return fmt.Errorf("failed to upload file with status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// HTTPHandler handles the HTTP requests from then connector service
+type HTTPHandler struct {
+	core.Adapter
+}
+
+func (ht *HTTPHandler) processMessage(w http.ResponseWriter, req *http.Request) {
+	ctx := context.Background()
+	activity, err := ht.Adapter.ParseRequest(ctx, req)
+	if err != nil {
+		fmt.Println("Failed to parse request.", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	err = ht.Adapter.ProcessActivity(ctx, activity, customHandler)
+	if err != nil {
+		fmt.Println("Failed to process request.", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	fmt.Println("Request processed successfully.")
+}
+
+func main() {
+	setting := core.AdapterSetting{
+		AppID:       os.Getenv("APP_ID"),
+		AppPassword: os.Getenv("APP_PASSWORD"),
+	}
+
+	adapter, err := core.NewBotAdapter(setting)
+	if err != nil {
+		log.Fatal("Error creating adapter: ", err)
+	}
+
+	httpHandler := &HTTPHandler{adapter}
+
+	http.HandleFunc("/api/messages", httpHandler.processMessage)
+	fmt.Println("Starting server on port:3978...")
+	http.ListenAndServe(":3978", nil)
+}

--- a/schema/model_upload_info.go
+++ b/schema/model_upload_info.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 InfraCloud Technologies
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package schema
+
+// UploadInfo contains info to upload contents
+type UploadInfo struct {
+	// ContentUrl is a direct link to the final location of the file on OneDrive.
+	ContentURL string
+	// FileType is the file type, as determined by OneDrive.
+	FileType string
+	// Name is the name of the file. Note that this may be different from the name that the bot proposed initially.
+	Name string
+	// UniqueID is an unique ID set for the contents.
+	UniqueID string
+	// UploadURL is the upload URL of the file. This points to a OneDrive upload session for the file. The upload session is valid for 15 minutes.
+	UploadURL string
+}


### PR DESCRIPTION
This PR:
- Adds `invoke` activity handler  to support file upload
- Add file-upload sample to show file upload workflow 

Fixes: https://github.com/infracloudio/msbotbuilder-go/issues/25